### PR TITLE
MockサーバーURLを最新のものに修正

### DIFF
--- a/FLATApp/FLATApp/Api/Api.swift
+++ b/FLATApp/FLATApp/Api/Api.swift
@@ -23,10 +23,10 @@ enum HttpMethod{
 
 public final class Api{
     private init(){}
-    // static var baseUrl = "http://34.68.157.198:8080"
-//    static var baseUrl = "http://127.0.0.1:3000"
-    // static var baseUrl = "http://odajimaaminoMacBook-Pro.local:3000"
-    static var baseUrl = "http://enPiT2019MBA-02.local:3000"
+    static var baseUrl = "http://35.239.225.65:8080" //MockServerUrl (8/12/2022)
+    //static var baseUrl = "http://127.0.0.1:3000"
+    //static var baseUrl = "http://odajimaaminoMacBook-Pro.local:3000"
+    //static var baseUrl = "http://enPiT2019MBA-02.local:3000"
     static let shared = URLSession.shared
     
     class func util<T1: Codable, T2: Decodable>(


### PR DESCRIPTION
APIクラスに記載されていたbaseUrlのうち、MockサーバーのURLを最新のURLに更新しました。