### PR TITLE
ステータス画面の一部を実装

### DIFF
--- a/FLATApp/FLATApp.xcodeproj/project.pbxproj
+++ b/FLATApp/FLATApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		120096C428AD3F4400C9CFEE /* StatusIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120096C328AD3F4400C9CFEE /* StatusIcon.swift */; };
 		2B2F791927511C340008E8B2 /* StartupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2F791827511C340008E8B2 /* StartupView.swift */; };
 		2B2F791B275137960008E8B2 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2F791A275137960008E8B2 /* LoginView.swift */; };
 		2B2F79A227526AFD0008E8B2 /* LabledBigButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2F79A127526AFD0008E8B2 /* LabledBigButtonStyle.swift */; };
@@ -39,6 +40,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		120096C328AD3F4400C9CFEE /* StatusIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusIcon.swift; sourceTree = "<group>"; };
 		2B2F791827511C340008E8B2 /* StartupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupView.swift; sourceTree = "<group>"; };
 		2B2F791A275137960008E8B2 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		2B2F79A127526AFD0008E8B2 /* LabledBigButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabledBigButtonStyle.swift; sourceTree = "<group>"; };
@@ -84,6 +86,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		12FE993228E1A00800F807B2 /* StatusSubViews */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = StatusSubViews;
+			sourceTree = "<group>";
+		};
 		2B2F79A0275264DB0008E8B2 /* InitialStartup */ = {
 			isa = PBXGroup;
 			children = (
@@ -138,6 +147,7 @@
 				2BB69E30271147A600275485 /* NamesearchView.swift */,
 				E4543432274A0A37001ECB14 /* CommonComponents */,
 				2BA9A2A2271620CC00BECC03 /* StatusView.swift */,
+				12FE993228E1A00800F807B2 /* StatusSubViews */,
 				2B72206C27302C5200937AE5 /* Bluetooth.swift */,
 				2B9DB79327417116003A5DDD /* SearchBeacon.swift */,
 				2BB69DF02710A1C800275485 /* Assets.xcassets */,
@@ -174,6 +184,7 @@
 				E4543433274A0A62001ECB14 /* LabeledButtonStyle.swift */,
 				2B2F79A127526AFD0008E8B2 /* LabledBigButtonStyle.swift */,
 				2B2F79A327526DDB0008E8B2 /* ButtonColor.swift */,
+				120096C328AD3F4400C9CFEE /* StatusIcon.swift */,
 			);
 			path = CommonComponents;
 			sourceTree = "<group>";
@@ -251,6 +262,7 @@
 			files = (
 				2B2F79A227526AFD0008E8B2 /* LabledBigButtonStyle.swift in Sources */,
 				E41B9D0F273B2BEE00D3AB80 /* SearchUser.swift in Sources */,
+				120096C428AD3F4400C9CFEE /* StatusIcon.swift in Sources */,
 				2B72206D27302C5200937AE5 /* Bluetooth.swift in Sources */,
 				E42D457F274728020051004D /* Tabs.swift in Sources */,
 				2BA9A2A3271620CC00BECC03 /* StatusView.swift in Sources */,

--- a/FLATApp/FLATApp/CommonComponents/StatusIcon.swift
+++ b/FLATApp/FLATApp/CommonComponents/StatusIcon.swift
@@ -1,0 +1,49 @@
+//
+//  StatusIcon.swift
+//  FLATApp
+//
+//  Created by Yourein on 2022/08/18.
+//
+
+import SwiftUI
+
+struct onSchoolIcon: View {
+    var body : some View{
+        Image(systemName: "circle.fill")
+            .foregroundColor(.green)
+            .font(.system(size: 50))
+    }
+}
+
+struct freeNowIcon: View {
+    var body : some View{
+        Image(systemName: "circle.fill")
+            .foregroundColor(.blue)
+            .font(.system(size: 50))
+    }
+}
+
+struct busyNowIcon: View{
+    var body : some View {
+        if #available(iOS 15.0, *) {
+            Image(systemName: "circle.fill")
+                .foregroundColor(.red)
+                .font(.system(size: 50))
+                .overlay(content: {
+                    Rectangle()
+                        .foregroundColor(.white)
+                        .frame(width: 40, height: 8)
+                })
+        } else {
+            Image(systemName: "circle.fill")
+        }
+    }
+}
+
+struct notOnSchoolIcon: View {
+    var body : some View {
+        Image(systemName: "circle.fill")
+            .foregroundColor(.gray)
+            .font(.system(size: 50))
+    }
+}

--- a/FLATApp/FLATApp/ContentView.swift
+++ b/FLATApp/FLATApp/ContentView.swift
@@ -8,32 +8,36 @@
 import SwiftUI
 
 struct ContentView: View{ //メイン画面
-    
-    
     init(){
         UITabBar.appearance().backgroundColor = UIColor(red: 0.93, green: 0.93, blue: 0.93, alpha: 1)
     }
     @State private var selection = 0
+    @State var isLoggedIn: Bool = true;
     //    @ObservedObject var timerHolder = TimerHolder()
     var BluetoothScan = Bluetooth()
     
     var body: some View {
-        TabView(selection: $selection){
-            PlaceView()
-                .tabItem {
-                    Image(systemName: "mappin.and.ellipse")
-                }
-                .tag(0)
-            FriendListView()
-                .tabItem {
-                    Image(systemName: "person")
-                }
-                .tag(1)
-            StatusView()
-                .tabItem {
-                    Image(systemName: "face.smiling")
-                }
-                .tag(2)
+        if (isLoggedIn) {
+            TabView(selection: $selection){
+                PlaceView()
+                    .tabItem {
+                        Image(systemName: "mappin.and.ellipse")
+                    }
+                    .tag(0)
+                FriendListView()
+                    .tabItem {
+                        Image(systemName: "person")
+                    }
+                    .tag(1)
+                StatusView(isLoggedIn: $isLoggedIn)
+                    .tabItem {
+                        Image(systemName: "face.smiling")
+                    }
+                    .tag(2)
+            }
+        }
+        else {
+            StartupView()
         }
     }
 }

--- a/FLATApp/FLATApp/StatusView.swift
+++ b/FLATApp/FLATApp/StatusView.swift
@@ -9,22 +9,132 @@ import SwiftUI
 
 struct StatusView: View { // アイコン画面 ??? ステータス画面
     @AppStorage("name") var name = "name"
-    @AppStorage("id") var id = 0
-    @AppStorage("spot") var spot = "name"
-    @AppStorage("loggedinAt") var loggedinAt = "name"
-    @AppStorage("ifFirstVisit") var isFirstVisit = false
-    @AppStorage("iconPath") var iconPath = ""
-    @State var toHome: Bool = false
+    @Binding var isLoggedIn: Bool
     var body: some View {
         VStack{
+            iconView()
+            Text("\(self.name)").font(.title)
+            HStack(){
+                Rectangle()
+                    .foregroundColor(Color("primary"))
+                    .frame(width: 270, height: 3)
+            }
+            Spacer()
+            settingList(isLoggedIn: $isLoggedIn)
+        }
+    }
+}
+
+struct iconView: View {
+    @AppStorage("iconPath") var iconPath = ""
+    @AppStorage("status") var status:Int = 0
+    
+    var body: some View{
+        if #available(iOS 15.0, *) {
+            IconLoaderView(size: 160, withUrl: iconPath).overlay(content: {
+                VStack{
+                    Spacer()
+                    HStack{
+                        Spacer()
+                        if (status == 0){ //学校にいる
+                            onSchoolIcon()
+                        }
+                        else if (status == 1){ //今暇
+                            freeNowIcon()
+                        }
+                        else if (status == 2){ //忙しい
+                            busyNowIcon()
+                        }
+                        else { //学校にいない or error
+                            notOnSchoolIcon()
+                        }
+                    }
+                }
+            })
+        } else {
+            //iOS15がサポートされていない場合はIconだけ表示する
             IconLoaderView(size: 160, withUrl: iconPath)
-            Text("your name is \(self.name)")
-            Text("your id is \(self.id)")
-            Text("your spot is \(self.spot)")
-            Text("your loggedinAt is \(self.loggedinAt)")
-            Text("your isFirstVisit is \(self.isFirstVisit ? "True" : "False")")
+        }
+    }
+}
+
+struct settingList: View{
+    @Binding var isLoggedIn: Bool
+    
+    var body: some View{
+        //Heightが固定値なのはListを下に寄せるため
+        //Listに必要な要素が増えたらHeightの値をそれに合わせて増やすこと
+        //ここを動的にできるようになったら嬉しい(そもそもできるかわかってない)
+        List{
+            Section {
+                nameSettingRow()
+                iconSettingRow()
+                statusSettingRow()
+                logoutRow(isLoggedIn: $isLoggedIn)
+            } header: {
+                Text("アカウント設定")
+            }
+        }.frame(height: 260.0).listStyle(.plain)
+    }
+}
+
+struct nameSettingRow: View {
+    var body: some View {
+        HStack{
+            Text("名前を変更する")
+            Spacer()
+            Button (action: {
+                //TODO: 名前変更の中身
+                //これはどこに書くべき? (更新処理はApiに、変更のViewはこのファイルかまた別のファイルに?)
+                print("Here: nameSettingRow")
+            }){
+                Image(systemName: "chevron.right")
+            }
+        }
+    }
+}
+
+struct iconSettingRow: View{
+    var body: some View {
+        HStack{
+            Text("アイコンを変更する")
+            Spacer()
+            Button (action: {
+                //TODO: アイコン変更の中身
+                //機能としてデカイのでファイル分けてもいいかも
+                print("Here: iconsettingRow")
+            }){
+                Image(systemName: "chevron.right")
+            }
+        }
+    }
+}
+
+struct statusSettingRow: View{
+    var body: some View {
+        HStack {
+            Text("ステータスを変更する")
+            Spacer()
+            Button (action: {
+                //TODO: ステータス変更の中身
+                //ファイル分けるかちょっと迷ってる。分けてもいいかも。
+                print("Here: statusSettingRow")
+            }){
+                Image(systemName: "chevron.right")
+            }
+        }
+    }
+}
+
+struct logoutRow: View{
+    @Binding var isLoggedIn: Bool
+    @AppStorage("id") var id = 1
+    var body: some View{
+        HStack{
+            Text("ログアウトする").foregroundColor(.red)
+            Spacer()    
             Button(action: {
-                // TODO: logout
+                //ログアウト処理
                 logout(userId: UserId(id: self.id), success: {msg in
                     print(msg)
                     UserDefaults.standard.set(-1, forKey: "id")
@@ -33,23 +143,20 @@ struct StatusView: View { // アイコン画面 ??? ステータス画面
                     UserDefaults.standard.set(0, forKey: "status")
                     UserDefaults.standard.set("", forKey: "loggedinAt")
                     UserDefaults.standard.set(true, forKey: "isFirstVisit")
-                    toHome = true
+                    isLoggedIn = false
                 }){(error) in
                     print(error)
                 }
             }){
-                Text("logout")
-            }
-            .buttonStyle(LabeledButtonStyle(type: .cancel))
-            .fullScreenCover(isPresented: $toHome){
-                StartupView()
+                Image(systemName: "chevron.right")
             }
         }
     }
 }
 
 struct IconView_Previews: PreviewProvider {
+    @State static var isLoggedIn:Bool = true
     static var previews: some View {
-        StatusView()
+        StatusView(isLoggedIn: $isLoggedIn)
     }
 }

--- a/FLATApp/FLATApp/StatusView.swift
+++ b/FLATApp/FLATApp/StatusView.swift
@@ -11,16 +11,20 @@ struct StatusView: View { // アイコン画面 ??? ステータス画面
     @AppStorage("name") var name = "name"
     @Binding var isLoggedIn: Bool
     var body: some View {
-        VStack{
-            iconView()
-            Text("\(self.name)").font(.title)
-            HStack(){
-                Rectangle()
-                    .foregroundColor(Color("primary"))
-                    .frame(width: 270, height: 3)
+        NavigationView{
+            VStack{
+                iconView()
+                Text("\(self.name)").font(.title)
+                HStack(){
+                    Rectangle()
+                        .foregroundColor(Color("primary"))
+                        .frame(width: 270, height: 3)
+                }
+                Spacer()
+                settingList(isLoggedIn: $isLoggedIn)
             }
-            Spacer()
-            settingList(isLoggedIn: $isLoggedIn)
+            .navigationBarHidden(true)
+            .navigationBarTitle(Text("Home"))
         }
     }
 }
@@ -82,14 +86,12 @@ struct nameSettingRow: View {
     var body: some View {
         HStack{
             Text("名前を変更する")
-            Spacer()
-            Button (action: {
-                //TODO: 名前変更の中身
-                //これはどこに書くべき? (更新処理はApiに、変更のViewはこのファイルかまた別のファイルに?)
-                print("Here: nameSettingRow")
-            }){
-                Image(systemName: "chevron.right")
-            }
+            
+            //NavigationLink内に存在するViewは基本的に灰色に塗りつぶされて表示される。
+            //このままだと右矢印(chevron.right)も塗りつぶされて表示されるので、
+            //NavigationLinkを透明度0で置いて、chevron.rightは別に描画している
+            NavigationLink(destination: nameSettingsView()){ EmptyView() }.opacity(0)
+            Image(systemName: "chevron.right")
         }
     }
 }
@@ -151,6 +153,45 @@ struct logoutRow: View{
                 Image(systemName: "chevron.right")
             }
         }
+    }
+}
+
+struct nameSettingsView: View {
+    @State var newnickname: String = ""
+    
+    var body: some View {
+        VStack{
+            //EmptyView()
+            
+            //この状態だとHeightの値を変えてもテキストボックスのサイズが変わらないので、
+            //SecureFieldを使ってもいいかも
+            TextField("未来太郎", text: $newnickname)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(width:327, height: 40)
+                .padding(10.0)
+                .keyboardType(.default)
+                .autocapitalization(.none)
+            
+            Button(action: {
+                if !validateName(name: newnickname) {
+                    print("invalid name")
+                    return
+                }
+                
+                //TODO: 名前の変更処理を書く
+            }
+            ){
+                Text("決定")
+                    .frame(width: 163, height: 40)
+                    .foregroundColor(Color.white)
+                    .background((Color("primary")))
+                    .cornerRadius(30, antialiased: true)
+            }
+            
+            Spacer()
+        }
+            .navigationBarTitle("名前を変更", displayMode: .inline)
+            .padding(.top, 50)
     }
 }
 


### PR DESCRIPTION
- ログイン前と後で表示される画面が変更されるようにUpdate
- ステータス画面の見た目を実装
- 現在ステータスに基づいてステータス画面のアイコン右下にインジケーターを表示
- 名前を変更ボタンを押すと名前変更のViewに遷移するように

[Issue2 - アーキテクチャをマシにする](https://github.com/FLAT-ICT/FLAT-iOS/issues/2) の通り、Viewにロジックを書いているところがいくつかあるので、分離したい気持ち。

他のiOSメンバーが開発を始めそうな予感がしたので、コンフリクト回避のために一度DevelopブランチにPRを投げておきたかった。